### PR TITLE
Make footer links span width of page

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -25,7 +25,7 @@
   </div>
   <div class="usa-footer__primary-section bg-primary text-white padding-y-8">
     <div class="usa-footer__primary-container grid-row">
-      <div class="desktop-lg:grid-col-8">
+      <div class="grid-col-auto">
         <nav
           class="usa-identifier__section usa-identifier__section--required-links"
           aria-label="Important links"


### PR DESCRIPTION
## Changes proposed in this pull request:
- On desktop, make footer links span the width of the container

Before:
<img width="1155" height="288" alt="Screenshot 2025-09-12 at 11 57 23 AM" src="https://github.com/user-attachments/assets/ecf47439-53ba-4834-aa8f-ccdb602700e7" />

After:
<img width="1193" height="238" alt="Screenshot 2025-09-12 at 11 57 08 AM" src="https://github.com/user-attachments/assets/5ff0306f-6657-4866-8be3-d5787e05e358" />

## security considerations
None