### PR TITLE
Remove "pages" from permalink

### DIFF
--- a/pages/pages.11tydata.js
+++ b/pages/pages.11tydata.js
@@ -1,0 +1,15 @@
+export default {
+  permalink: (data) => {
+    let pagePath = data.page.inputPath
+      .replace(/^\.\/pages/, "")
+      .replace(/\.(md|html|njk)$/, "");
+
+    if (pagePath.endsWith("/index")) {
+      pagePath = pagePath.slice(0, -6) + "/";
+    } else {
+      pagePath += "/index.html"; // Add .html extension for non-index files
+    }
+
+    return pagePath;
+  },
+};


### PR DESCRIPTION
## Changes proposed in this pull request:
- Remove `/pages/` from the permalink of all pages in the `/pages/` directory
- Example http://localhost:8080/pages/about-us/who-we-are/ -> http://localhost:8080/about-us/who-we-are/
- 
## security considerations
None