### PR TITLE
Create redirect template

### DIFF
--- a/pages/about-us/council-members.md
+++ b/pages/about-us/council-members.md
@@ -1,5 +1,7 @@
 ---
 title: Council Members
+redirect_from:
+  - /people/council-members
 eleventyNavigation:
   key: council-members
   parent: about-us

--- a/redirect.njk
+++ b/redirect.njk
@@ -1,0 +1,37 @@
+---js
+{
+  pagination: {
+    data: "collections.all",
+    size: 1,
+    alias: "redirect",
+    before: function (data) {
+      return data.reduce((redirects, page) => {
+        if (Array.isArray(page.data.redirect_from)) {
+          for (let url of page.data.redirect_from) {
+            redirects.push({ to: page.url, from: url });
+          }
+        } else if (typeof page.data.redirect_from === 'string') {
+          redirects.push({ to: page.url, from: page.data.redirect_from });
+        }
+        return redirects;
+      }, []);
+    },
+    addAllPagesToCollections: false,
+  },
+  permalink: "{{ redirect.from }}/index.html",
+  eleventyExcludeFromCollections: true,
+}
+---
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8" />
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="{{ redirect.to | url }}" />
+  <script>
+    location = '{{ redirect.to | url }}';
+  </script>
+  <meta http-equiv="refresh" content="0; url={{ redirect.to | url }}" />
+  <meta name="robots" content="noindex" />
+  <h1>Redirecting&hellip;</h1>
+  <a href="{{ redirect.to | url }}">Click here if you are not redirected.</a>
+</html>


### PR DESCRIPTION
## Changes proposed in this pull request:
- Set's up a `redirect_from` frontmatter key to redirect pages similar to Jekyll
- Implemented example for Council Members

## security considerations
None